### PR TITLE
Updates in some Biana parsers

### DIFF
--- a/biana/BianaParser/cogParser_2014.py
+++ b/biana/BianaParser/cogParser_2014.py
@@ -1,0 +1,246 @@
+"""
+    BIANA: Biologic Interactions and Network Analysis
+    Copyright (C) 2009  Javier Garcia-Garcia, Emre Guney, Baldo Oliva
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+from bianaParser import *
+
+class CogParser(BianaParser):
+    """
+    COG Parser Class
+    """
+
+    name = "cog2014"
+    description = "Clusters of Orthologous Groups of proteins (COGs)"
+    external_entity_definition = "An element in a COG"
+    external_entity_relations = "A COG"
+
+    def __init__(self):
+
+        # Start with the default values
+
+        BianaParser.__init__(self, default_db_description = "COG database",
+                             default_script_name = "cogParser_2014.py",
+                             default_script_description = CogParser.description,
+                             additional_optional_arguments = [])
+        self.default_eE_attribute = "cog"
+	#self.is_promiscuous = True
+
+
+    def parse_database(self):
+
+        # FIRST: Check that all the files exist
+        if os.path.isdir(self.input_file):
+            self.input_path = self.input_file
+        else:
+            raise ValueError("You must specify a path instead of a file")
+
+        files = ["prot2003-2014.fa","prot2003-2014.tab","prot2003-2014.gi2gbk.tab","genomes2003-2014.tab","fun2003-2014.tab","cognames2003-2014.tab", "cog2003-2014.csv"] #"pa" for the moment it is not necessary
+
+        for current_file in files:
+            if os.path.exists(self.input_path+os.sep+current_file) is False:
+                raise ValueError("File %s is missing in %s" %(current_file, self.input_path))
+
+
+        
+        # Read correspondence letters to TaxID for the external entities
+        # Change with respect to the old COG (by Quim Aguirre)
+
+        species_file_fd = open(self.input_path+os.sep+"genomes2003-2014.tab",'r')
+        specie_taxid_dict = {}
+
+        # We create a dict with FTP name (specie) as key, and TaxID as value
+        for line in species_file_fd:
+            if line[0] != "#":
+                (code, tax_id, FTP_name) = line.strip().split("\t")
+                ## Example --> Acamar   329726  Acaryochloris_marina_MBIC11017_uid58167
+                specie_taxid_dict[FTP_name.lower()] = tax_id
+        
+        species_file_fd.close()
+
+
+        # Read the functional information
+        # Change with respect to the old COG (by Quim Aguirre)
+
+        function_dict = {}
+        function_file_fd = open(self.input_path+os.sep+"fun2003-2014.tab",'r')
+
+        # We create a dict with the functional code as key, and the function name as value
+        for line in function_file_fd:
+            if line[0] != "#":
+                (fun_code, fun_name) = line.strip().split("\t")
+                ## Example --> H    Coenzyme transport and metabolism
+                function_dict[fun_code] = fun_name
+
+        function_file_fd.close()
+
+        
+        # Read the name (genbank GI), refseq and (NCBI protein) genbank accession correspondence
+        # Change with respect to the old COG (by Quim Aguirre)
+
+        name2refseq_dict = {}
+        name2gb_dict = {}
+        name2refseqgb_file_fd = open(self.input_path+os.sep+"prot2003-2014.gi2gbk.tab",'r')
+
+        # We create two dictionaries
+        ## One contains the GI as key, and the RefSeq as value
+        ## The other contains the GI as key, and the GenBank accession as value
+        for line in name2refseqgb_file_fd:
+            (protein_name, refseq, genbank) = line.strip().split("\t")
+            ## Example --> 103485499	YP_615060	ABF51727
+            name2refseq_dict[protein_name.lower()] = refseq.lower()
+            name2gb_dict[protein_name.lower()] = genbank.lower()
+
+        name2refseqgb_file_fd.close()
+
+
+        # Obtain, from the COGs file, to which specie belongs each protein
+        # Obtain also the information for the COGs, description, functional_classification...
+        # Change with respect to the old COG (by Quim Aguirre)
+
+        cognames = open(self.input_path+os.sep+"cognames2003-2014.tab",'r')
+        cog2003_2014 = open(self.input_path+os.sep+"cog2003-2014.csv",'r')
+
+        name2species_dict = {}
+        cogs_components_dict = {}
+        cogs_funct_dict = {}
+        cogs_description_dict = {}
+        name2cogs_dict = {}
+
+        ##--> Obtain, from "cognames2003-2014.tab", the COG number, COG functional annotation code and description
+        ## We create three dicts
+        ### cogs_description_dict --> Contains the COG as key, and the description as value
+        ### cogs_funct_dict --> Contains the COG as key, and the function as value
+        ### In the dict "cogs_components_dict", we create keys containing COGs, and we set empty lists as their default values
+        for line in cognames:
+
+            if line[0] != "#":
+                (COG, fun_code, description) = line.strip().split("\t")
+                ## Example --> COG0001  H   Glutamate-1-semialdehyde aminotransferase
+
+                cogs_description_dict[COG] = description
+                #print(COG, cogs_description_dict[COG])
+                cogs_funct_dict[COG] = fun_code
+                #print(COG, cogs_funct_dict[COG])        
+                cogs_components_dict.setdefault(COG,[])
+
+        cognames.close()
+
+        ##--> Obtain, from "cog2003-2014.csv", the COG number, protein id and its corresponding genome
+        for line in cog2003_2014:
+            (domain_id, genome, protein, prot_len, dom_start, dom_end, COG, membership, nothing) = line.split(',')
+            ## Example --> 333894695,Alteromonas_SN2_uid67349,333894695,427,1,427,COG0001,0,
+    
+            try:
+                # Here, if the COG exists inside the dictionary "cogs_components_dict", we add the proteins that correspond to this COG
+                cogs_components_dict[COG].append(protein)
+            except:
+                continue
+            # Here, we create two dicts:
+            ## name2cogs_dict --> containing the GI as key, and the COG as value
+            ## name2species_dict --> containing the GI as key, and the FTP name as value
+            ### If a protein has more than one COG/genome, they are appended/added inside the list/set
+            name2cogs_dict.setdefault(protein,[]).append(COG)
+            name2species_dict.setdefault(protein.lower(),set()).add(genome.lower())
+
+        cog2003_2014.close()
+        
+
+
+        def create_and_insert_eE():
+            # Create an External Entity of type "protein"
+            eE_object = ExternalEntity( source_database = self.database, type="protein" )
+            # Add an attribute to the External Entity --> the protein sequence
+            eE_object.add_attribute(ExternalEntityAttribute( attribute_identifier = "proteinsequence", 
+                                                                     value = ProteinSequence("".join(sequence)),
+								     type = "cross-reference"))
+
+            if name2refseq_dict.has_key(protein_name.lower()):
+                # Add an attribute to the External Entity --> the RefSeq identifier
+                eE_object.add_attribute(ExternalEntityAttribute( attribute_identifier = "RefSeq", 
+                                                                 value = name2refseq_dict[protein_name.lower()],
+								 type="cross-reference" ))
+
+            if name_to_gb_dict.has_key(protein_name.lower()):
+                # Add an attribute to the External Entity --> the GeneBank accession
+                eE_object.add_attribute(ExternalEntityAttribute( attribute_identifier = "AccessionNumber", 
+                                                                 value = name_to_gb_dict[protein_name.lower()],
+								 type="cross-reference" ))
+                
+            if name2species_dict.has_key(protein_name.lower()):
+                species = name2species_dict[protein_name.lower()]
+
+                if len(species)>1:
+                    print "Protein %s has more than a single specie assigned!" %protein_name
+
+                for current_specie in species:
+                    # Add an attribute to the External Entity --> the TaxIDs of the protein
+                    # We use the dictionary "specie_taxid_dict" in order to insert the corresponding TaxID to the specie
+                    eE_object.add_attribute(ExternalEntityAttribute( attribute_identifier = "taxID",
+                                                                     value = specie_taxid_dict[current_specie.lower()],
+		    					      type = "cross-reference") )
+
+                for current_cog in name2cogs_dict[protein_name.lower()]:
+                    # Add an attribute to the External Entity --> the corresponding COG identifiers of the protein
+                    eE_object.add_attribute( ExternalEntityAttribute( attribute_identifier = "COG",
+                                                                      value = current_cog,
+								      type="cross-reference" ) )
+                    for current_function in cogs_funct_dict[current_cog]:
+                        # Add an attribute to the External Entity --> the COG function
+                        # Here, we use the "function_dict" to add the function description corresponding to the function code (current_function)
+                        eE_object.add_attribute( ExternalEntityAttribute( attribute_identifier = "function",
+                                                                          value = function_dict[current_function],
+									  type="cross-reference" ) )
+
+                    # Add an attribute to the External Entity --> the protein name, in this case is classified as GenBank GI
+                    eE_object.add_attribute( ExternalEntityAttribute( attribute_identifier = "GI",
+                                                                      value = protein_name,
+								      type="cross-reference" ) )
+                
+
+                self.biana_access.insert_new_external_entity( externalEntity = eE_object )
+            
+
+        # Read the sequences and insert the external entities
+        # Change with respect to the old COG (by Quim Aguirre)
+
+        fasta_file_fd = open(self.input_path+os.sep+"prot2003-2014.fa",'r')
+        sequence = []
+        protein_name_regex = re.compile(">gi\|(.+)\|ref.*")
+        ## Example of FASTA header --> >gi|103485499|ref|YP_615060.1| chromosomal replication initiation protein [Sphingopyxis alaskensis RB2256]
+        protein_name = None
+
+        for line in fasta_file_fd:
+
+            m = protein_name_regex.match(line)
+            if m:
+                if len(sequence)>0:
+                    create_and_insert_eE()
+
+                sequence = []
+                protein_name = m.group(1)
+            else:
+                sequence.append(line.strip())
+
+        fasta_file_fd.close()
+
+        if len(sequence)>0:
+            create_and_insert_eE()
+
+
+        # FINALLY, IT WOULD BE POSSIBLE TO INSERT THE COGS AS A RELATION... IS IT NECESSARY? In principle, it is not necessary, as attribute networks can be generated...
+        # For the moment, not done

--- a/biana/BianaParser/hgncParser_2016.py
+++ b/biana/BianaParser/hgncParser_2016.py
@@ -1,0 +1,431 @@
+"""
+    BIANA: Biologic Interactions and Network Analysis
+    Copyright (C) 2009  Javier Garcia-Garcia, Emre Guney, Baldo Oliva
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+"""
+File          : hgnc2piana.py
+Author        : Javier Garcia
+Creation      : 14 November 2007
+Contents      : fills up tables in database piana with information from HGNC
+Called from   : 
+Modifications : at April of 2016 by Quim Aguirre in order to adapt the parser
+                to the changes of the names of the different fields
+Information   : http://www.genenames.org/help/statistics-downloads
+=======================================================================================================
+
+"""
+
+
+## STEP 1: IMPORT NECESSARY MODULES
+
+from bianaParser import *
+
+
+class HGNCParser(BianaParser):
+    """
+    HGNC Parser Class
+    """
+
+    name = "hgnc_2016"
+    description = "This file implements a program that fills up tables in BIANA database with information from HGNC"
+    external_entity_definition = "A external entity represents a protein"
+    external_entity_relations = ""
+
+    def __init__(self):
+
+        # Start with the default values
+
+        BianaParser.__init__(self, default_db_description = "HUGO Gene Nomenclature Committee",
+                             default_script_name = "hgncParser_2016.py",
+                             default_script_description = HGNCParser.description,
+                             additional_compulsory_arguments = [])
+        self.default_eE_attribute = "hgnc"
+        
+    def parse_database(self):
+        """
+        Method that implements the specific operations of HGNC parser
+
+        # Updated dict
+        0 : HGNC ID
+        1 : Approved Symbol
+        2 : Approved Name
+        3 : Status
+        4 : Previous Symbols
+        5 : Aliases
+        6 : Chromosome
+        7 : Accession Numbers
+        8 : RefSeq IDs
+
+        # Python generated dict
+        0 :  HGNC ID
+        1 :  Approved Symbol
+        2 :  Approved Name
+        3 :  Status
+        4 :  Locus Type
+        5 :  Previous Symbols
+        6 :  Previous Names
+        7 :  Aliases
+        8 :  Name Aliases
+        9 :  Chromosome
+        10 :  Date Approved
+        11 :  Date Modified
+        12 :  Date Symbol Changed
+        13 :  Date Name Changed
+        14 :  Accession Numbers
+        15 :  Enzyme IDs
+        16 :  Entrez Gene ID
+        17 :  Ensembl Gene ID
+        18 :  Mouse Genome Database ID
+        19 :  Specialist Database Links
+        20 :  Specialist Database IDs
+        21 :  Pubmed IDs
+        22 :  RefSeq IDs
+        23 :  Gene Family Name
+        24 :  Record Type
+        25 :  Primary IDs
+        26 :  Secondary IDs
+        27 :  CCDS IDs
+        28 :  VEGA IDs
+        29 :  Locus Specific Databases
+        30 :  GDB ID (mapped data)
+        31 :  Entrez Gene ID (mapped data supplied by NCBI)
+        32 :  OMIM ID (mapped data supplied by NCBI)
+        33 :  RefSeq (mapped data supplied by NCBI)
+        34 :  UniProt ID (mapped data supplied by UniProt)
+        35 :  Ensembl ID (mapped data supplied by Ensembl)
+        36 :  UCSC ID (mapped data supplied by UCSC)
+        37 :  Rat Genome Database ID (mapped data supplied by RGD)
+
+        """
+        
+
+		
+        # List of tables to lock. It is used to improve speed inserts, as the indices are not updated in each insert
+        # Commented. Locking all tables for the moment
+        # tables_to_lock = [PianaGlobals.crossReferenceSource_table,
+        #                   PianaGlobals.crossReferences_table]
+
+
+        # HGNC Fields are the following: (CD: Multiple values, comma delimited    QCD: Multiple Quoited values in a comma delimited list
+        #  0: HGNC ID
+        #  1: Approved Symbol (Oficial Gene Symbol)
+        #  2: Approved Name (Oficial Gene Name)
+        #  3: Status
+        #  4: Locus Type
+        #  5: Previous Symbols CD
+        #  6: Previous Names QCD
+        #  7: Aliases CD
+        #  8: Name Aliases QCD         # EMPTY!!!!
+        #  9: Chromosome
+        # 10: Date Approved
+        # 11: Date Modified
+        # 12: Date Symbol changed      NOT EXISTS!!!!
+        # 13: Date Name Changed
+        # 14: Accession Numbers CD
+        # 15: Enzyme ID CD
+        # 16: Entrez Gene ID (Replaeced Locus Link)
+        # 17: Ensembl Gene ID
+        # 18: MGD ID
+        # 19: Specialist Database Links (CD)
+        # 20: Specialist Database IDs (CD)         NOT EXISTS!!!!
+        # 21: Pubmed IDs (CD)
+        # 22: RefSeq IDs (CD) Only One is selected!
+        # 23: Gene Family Name (CD)
+        # 24: Record Type
+        # 25: Primary IDs
+        # 26: Secondary IDs
+        # 27: CCDS IDs
+        # 28: VEGA IDs
+        # 29: Locus Specific Databases
+        # 30: GBD ID
+        # 31: Entrez Gene ID
+        # 32: OMIM ID
+        # 33: RefSeq
+        # 34: Uniprot ID
+        # 35: EnsembL
+        # 36: UCSC ID
+        # 37: RGD ID
+        
+
+        self.initialize_input_file_descriptor()
+
+        line_number=0
+        header_columns = {}
+
+        columns = 0
+
+        for line in self.input_file_fd:
+
+            line_number += 1
+            
+
+            # Read columns of header line into dictionary
+            if line_number == 1:
+                value_list = line.strip().split("\t")
+                header_columns = dict([ (value_list[i], i) for i in xrange(len(value_list))])
+                #sys.stderr.write("%s columns in header\n" %len(value_list))
+                columns = len(value_list)
+
+            # Example of header row:
+            # hgnc_id	symbol	name	locus_group	locus_type	status	location	location_sortable	alias_symbol	alias_name	prev_symbol	prev_name	gene_family	gene_family_id	date_approved_reserved	date_symbol_changed	date_name_changed	date_modified	entrez_id	ensembl_gene_id	vega_id	ucsc_id	ena	refseq_accession	ccds_id	uniprot_ids	pubmed_id	mgd_id	rgd_id	lsdb	cosmic	omim_id	mirbase	homeodb	snornabase	bioparadigms_slc	orphanet	pseudogene.org	horde_id	merops	imgt	iuphar	kznf_gene_catalog	mamit-trnadb	cd	lncrnadb	enzyme_id	intermediate_filament_db                                
+
+            # Example of simple row:
+            # HGNC:18149	A4GALT	alpha 1,4-galactosyltransferase	protein-coding gene	gene with protein product	Approved	22q13.2	22q13.2	"A14GALT|Gb3S|P(k)|P1"	"Gb3 synthase|CD77 synthase|globotriaosylceramide synthase|lactosylceramide 4-alpha-galactosyltransferase"		alpha 1,4-galactosyltransferase (globotriaosylceramide synthase, P blood group)	Alpha 1,4-glycosyltransferases	442	2002-02-06		2008-07-31	2016-12-13	53947	ENSG00000128274	OTTHUMG00000150744	uc062ewl.1		NM_017436	CCDS14041	Q9NPC4	10854428	MGI:3512453	RGD:621583	LRG_795|http://www.lrg-sequence.org/LRG/LRG_795	A4GALT	607922															2.4.1.228	
+
+            if line_number>1:
+	
+                try:
+	            if line_number>1:
+
+                        line.strip()
+	            
+	            	# Create a new external entity object
+	            	hgnc_object = ExternalEntity( source_database = self.database, type="protein" )
+
+                        # ADDING TAXID AS IT ONLY CONTAINS HUMAN GENES
+                        hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier="taxid",
+                                                                          value=9606,
+                                                                          type="unique"))
+
+	            	line_fields = line.split("\t")
+
+                        
+                        if len(line_fields) != columns:
+                            sys.stderr.write("Incorrect fields number\n%s\n" %(line))
+
+                        
+
+	                column_index = header_columns["hgnc_id"]
+                        column_value =  line_fields[column_index].strip()
+                        if column_value.startswith("HGNC:"):
+                            hgnc_id = column_value[5:]
+                        else:
+                            hgnc_id = column_value
+	                # Take the values. Those that can be multiple values are stored in a list
+                        hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "hgnc", 
+                                                                          value = hgnc_id,
+                                                                          type = "unique" ))
+	                
+	                column_index = header_columns["symbol"]
+	                official_gene_symbol = line_fields[column_index].strip()
+                        hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "geneSymbol", 
+                                                                          value = official_gene_symbol,
+                                                                          type = "unique" ))
+	                
+	                column_index = header_columns["name"]
+	                official_gene_name = line_fields[column_index].strip()
+	                # Oficial gene Name is entered as a description
+                        hgnc_object.add_attribute( ExternalEntityAttribute(attribute_identifier = "description",
+                                                                           value = official_gene_name, type="unique" ))
+
+	                column_index = header_columns["alias_symbol"]
+	                aliases_symbol = line_fields[column_index].strip()
+	                if len(aliases_symbol)>0:
+                            if aliases_symbol.startswith('"') and aliases_symbol.endswith('"'):
+                                aliases_symbol = aliases_symbol[1:-1]
+                            aliases_symbol = [ x.strip() for x in aliases_symbol.split("|") ]
+                            [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "geneSymbol", 
+                                                                                value = x,
+                                                                                type = "alias" )) for x in aliases_symbol ]
+
+                        keyword = "alias_name"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    aliases_name = line_fields[column_index].strip()
+	                    if len(aliases_name)>0:
+                                if aliases_name.startswith('"') and aliases_name.endswith('"'):
+                                    aliases_name = aliases_name[1:-1]
+                                aliases_name = [ x.strip() for x in aliases_name.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "description", 
+                                                                                value = x,
+                                                                                type = "alias")) for x in aliases_name ]
+	                
+	                column_index = header_columns["prev_symbol"]
+	                previous_symbols = line_fields[column_index].strip()
+	                if len(previous_symbols)>0:
+                            if previous_symbols.startswith('"') and previous_symbols.endswith('"'):
+                                previous_symbols = previous_symbols[1:-1]
+                            previous_symbols = [ x.strip() for x in previous_symbols.split("|") ]
+                            [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "geneSymbol", 
+                                                                                value = x,
+                                                                                type = "previous")) for x in previous_symbols ]
+
+                        keyword = "prev_name"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    previous_names = line_fields[column_index].strip()
+	                    if len(previous_names)>0:
+				# some names have commas in between, so we will split based on ", " - fix by Laura Furlong
+                                if previous_names.startswith('"') and previous_names.endswith('"'):
+                                    previous_names = previous_names[1:-1]
+                                previous_names = [ x.strip() for x in previous_names.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "description", 
+                                                                                value = x, type="previous" )) for x in previous_names ]
+
+                        keyword = "entrez_id"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    geneIDs = line_fields[column_index].strip()
+	                    if len(geneIDs)>0:
+                                if geneIDs.startswith('"') and geneIDs.endswith('"'):
+                                    geneIDs = geneIDs[1:-1]
+                                geneIDs = [ x.strip() for x in geneIDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "geneID", 
+                                                                                    value = x,
+                                                                                    type = "cross-reference")) for x in geneIDs ]
+
+                        keyword = "ensembl_gene_id"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    ensemblIDs = line_fields[column_index].strip()
+	                    if len(ensemblIDs)>0:
+                                if ensemblIDs.startswith('"') and ensemblIDs.endswith('"'):
+                                    ensemblIDs = ensemblIDs[1:-1]
+                                ensemblIDs = [ x.strip() for x in ensemblIDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "ensembl", 
+                                                                                    value = x,
+                                                                                    type = "cross-reference")) for x in ensemblIDs ]
+	                	
+                        keyword = "ena"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    accessionIDs = line_fields[column_index].strip()
+	                    if len(accessionIDs)>0:
+                                if accessionIDs.startswith('"') and accessionIDs.endswith('"'):
+                                    accessionIDs = accessionIDs[1:-1]
+                                accessionIDs = [ x.strip() for x in accessionIDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "AccessionNumber", 
+                                                                                    value = x,
+                                                                                    type = "cross-reference")) for x in accessionIDs ]
+
+	                column_index = header_columns["refseq_accession"]
+	                refseqs = line_fields[column_index].strip()
+	                if len(refseqs)>0: 
+                            if refseqs.startswith('"') and refseqs.endswith('"'):
+                                refseqs = refseqs[1:-1]
+                            refseqs = [ x.strip() for x in refseqs.split("|") ]
+                            [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "refseq", 
+                                                                                value = x,
+                                                                                type = "cross-reference")) for x in refseqs ]
+
+                        keyword = "uniprot_ids"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    uniprotIDs = line_fields[column_index].strip()
+	                    if len(uniprotIDs)>0:
+                                if uniprotIDs.startswith('"') and uniprotIDs.endswith('"'):
+                                    uniprotIDs = uniprotIDs[1:-1]
+                                uniprotIDs = [ x.strip() for x in uniprotIDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "uniprotaccession", 
+                                                                                    value = x,
+                                                                                    type = "cross-reference")) for x in uniprotIDs ]
+	                	
+#                        keyword = "GDB ID (mapped data)"
+#                        if keyword in header_columns:
+#	                    column_index = header_columns[keyword]
+#	                    column_value = line_fields[column_index].strip()
+#	                    if len(column_value)>0:
+#                                GDB_IDs = [ x.lstrip("GDB:") for x in column_value.split(",") ]
+#                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "gdb", 
+#                                                                                    value = x,
+#                                                                                    type = "cross-reference" )) for x in GDB_IDs ]
+	                	
+                        keyword = "pubmed_id"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    pubmed_IDs = line_fields[column_index].strip()
+	                    if len(pubmed_IDs)>0:
+                                if pubmed_IDs.startswith('"') and pubmed_IDs.endswith('"'):
+                                    pubmed_IDs = pubmed_IDs[1:-1]
+                                pubmed_IDs = [ x.strip() for x in pubmed_IDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "pubmed", 
+                                                                                    value = x,
+                                                                                    type = "cross-reference")) for x in pubmed_IDs ]
+	                	
+                        keyword = "mgd_id"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    MGD_IDs = line_fields[column_index].strip()
+	                    if len(MGD_IDs)>0:
+                                if MGD_IDs.startswith('"') and MGD_IDs.endswith('"'):
+                                    MGD_IDs = MGD_IDs[1:-1]
+                                MGD_IDs = [ x.lstrip("MGI:") for x in MGD_IDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "mgi", 
+                                                                                    value = x,
+                                                                                    type = "cross-reference")) for x in MGD_IDs ]
+
+                        keyword = "rgd_id"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    RGD_IDs = line_fields[column_index].strip()
+	                    if len(RGD_IDs)>0:
+                                if RGD_IDs.startswith('"') and RGD_IDs.endswith('"'):
+                                    RGD_IDs = RGD_IDs[1:-1]
+                                RGD_IDs = [ x.lstrip("RGD:") for x in RGD_IDs.split("|") ]
+                                for current_rgd_id in RGD_IDs:
+                                    if current_rgd_id != "":
+                                        hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "rgd", 
+                                                                                      value = current_rgd_id,
+                                                                                      type = "cross-reference"))
+	                	
+                        keyword = "omim_id"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    omimIDs = line_fields[column_index].strip()
+	                    if len(omimIDs)>0:
+                                if omimIDs.startswith('"') and omimIDs.endswith('"'):
+                                    omimIDs = omimIDs[1:-1]
+                                omimIDs = [ x.strip() for x in omimIDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "mim",
+                                                                                    value = x, 
+			    							type="cross-reference")) for x in omimIDs ]
+	                	
+                        keyword = "imgt"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    imgtIDs = line_fields[column_index].strip()
+	                    if len(imgtIDs)>0:
+                                if imgtIDs.startswith('"') and imgtIDs.endswith('"'):
+                                    imgtIDs = imgtIDs[1:-1]
+                                imgtIDs = [ x.strip() for x in imgtIDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "IMGT", 
+                                                                                    value = x,
+                                                                                    type = "cross-reference")) for x in imgtIDs ]
+	                	
+                        keyword = "enzyme_id"
+                        if keyword in header_columns:
+	                    column_index = header_columns[keyword]
+	                    enzyme_IDs = line_fields[column_index].strip()
+	                    if len(enzyme_IDs)>0:
+                                if enzyme_IDs.startswith('"') and enzyme_IDs.endswith('"'):
+                                    enzyme_IDs = enzyme_IDs[1:-1]
+                                enzyme_IDs = [ x.strip() for x in enzyme_IDs.split("|") ]
+                                [ hgnc_object.add_attribute(ExternalEntityAttribute(attribute_identifier = "EC", 
+                                                                                value = x,
+                                                                                type = "cross-reference" ) ) for x in enzyme_IDs ]
+	                	
+	                # Save the object in the database            	
+	                self.biana_access.insert_new_external_entity( externalEntity = hgnc_object )
+	
+	
+                except:
+                    traceback.print_exc()
+                    sys.stderr.write("Error in parsing line %s\n" %(line_number))
+                    raise Exception;
+
+

--- a/biana/BianaParser/iRefIndexParser_2016.py
+++ b/biana/BianaParser/iRefIndexParser_2016.py
@@ -1,0 +1,493 @@
+"""
+    BIANA: Biologic Interactions and Network Analysis
+    Copyright (C) 2009  Javier Garcia-Garcia, Emre Guney, Baldo Oliva
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+from bianaParser import *
+from obo_index import obo_name_to_MI
+
+class iRefIndexParser(BianaParser):
+    """
+    Parser for iRefIndex MITAB 2.5 PPI files. Modified at April of 2016 
+    by Quim Aguirre to adapt the parser to iRefIndex MITAB 2.6
+    """
+
+    name = "iRefIndex_2016"
+    description = "This file implements the parser for iRefIndex"
+    external_entity_definition = "A protein"
+    external_entity_relations = "physical interaction"
+
+
+    def __init__(self):
+
+        # Start with the default values
+
+        BianaParser.__init__(self, default_db_description = "iRefIndex Database",
+                             default_script_name = "iRefIndexParser_2016.py",
+                             default_script_description = iRefIndexParser.description,
+                             additional_optional_arguments = [])
+        self.default_eE_attribute = "iRefIndex_ROGID"
+        self.initialize_input_file_descriptor()
+        return
+
+
+    def parse_database(self):
+        """
+        Parses the iRefIndex file
+
+        iRefIndex format explained at http://irefindex.org/wiki/index.php?title=README_MITAB2.6_for_iRefIndex
+        """
+
+        #irefindex:NeQ0QcVrpNzyqWlmp/HvG5FIRHA9606       irefindex:xjgJ54UxwS5DwnuMgn6A8XxjvsY9606       uniprotkb:P24593|refseq:NP_000590|entrezgene/locuslink:3488     uniprotkb:P35858|refseq:NP_004961|entrezgene/locuslink:3483  uniprotkb:IBP5_HUMAN|entrezgene/locuslink:IGFBP5        uniprotkb:ALS_HUMAN|entrezgene/locuslink:IGFALS MI:0000(-)      -       pubmed:-        taxid:9606      taxid:9606  MI:0000(aggregation)     MI:0923(irefindex)|MI:0000:(ophid)      irefindex:++1ALo0GitoAXTTz5lyLFlYtoO8|ophid:-   lpr:-|hpr:-|np:-        3488    3483    MI:0326(protein)        MI:0326(protein)    ++1ALo0GitoAXTTz5lyLFlYtoO8      X       2       3196230 4869527
+        
+        fields_dict = {}
+
+        external_entities_dict = {}   # Dictionary protein_id -> external Entity ID
+
+        external_entity_relations_dict = {}
+
+        mi_re = re.compile("MI:(\d+)\((.+)\)")
+
+        uniprot_entry_pattern = re.compile('[a-zA-Z0-9]{,10}_[a-zA-Z0-9]{,5}')
+        pdb_chain_pattern = re.compile('[a-zA-Z0-9]{4}_[a-zA-Z0-9]')
+        refseq_pattern = re.compile('[a-zA-Z0-9]{2}_[a-zA-Z0-9]+')
+        gbaccession_pattern = re.compile('[a-zA-Z]{3}[0-9]{5}')
+
+        for line in self.input_file_fd:
+
+            # PROCESS HEADER. Here I have an example of the current version header:
+            #uidA   uidB    altA    altB    aliasA  aliasB  method  author  pmids   taxa    taxb    interactionType sourcedb    interactionIdentifier   confidence  expansion   biological_role_A   biological_role_B   experimental_role_A experimental_role_B interactor_type_A   interactor_type_B   xrefs_A xrefs_B xrefs_Interaction   Annotations_A   Annotations_B   Annotations_Interaction Host_organism_taxid parameters_Interaction  Creation_date   Update_date Checksum_A  Checksum_B  Checksum_Interaction    Negative    OriginalReferenceA  OriginalReferenceB  FinalReferenceA FinalReferenceB MappingScoreA   MappingScoreB   irogida irogidb irigid  crogida crogidbcrigid   icrogida    icrogidb    icrigid imex_id edgetype    numParticipants
+            if line[0]=="#":
+                fields = line[1:].strip().split("\t")
+                for x in xrange(0, len(fields)):
+                    fields_dict[fields[x].lower()] = x
+            
+                continue
+
+            fields = line.strip().split("\t")
+
+            eE1_id = None
+            eE2_id = None
+
+            # Create or get external entities
+            if "0326" in fields[fields_dict["interactor_type_a"]]:
+
+                if fields[0] not in external_entities_dict:
+
+                    eE1 = ExternalEntity( source_database = self.database, type="protein" )
+
+                    # Primary ids:
+                    # In the previous versions, RogIDs were extracted from the columns "uida" and "uidb"
+                    # Now, these columns contain identifiers from major databases (uniprot, refseq...)
+                    # If we want the RogID, we need to take it from column column 33/34 (checksum_a/checksum_b)
+                    primary_id_t = fields[fields_dict["checksum_a"]]
+                    # Example --> rogid:6Y8uQAzJShSjVNH41+7FK8K1DXo9606
+                    t = primary_id_t.split(":")
+                    eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "irefindex_ROGID", value=t[1], type="unique") )
+
+
+                    alternative_ids = fields[fields_dict["alta"]].split("|")
+                    for current_id in alternative_ids:
+                        if current_id == "-":
+                            continue
+                        t = current_id.split(":")
+                        idtype = t[0].lower()
+                        idvalue = t[1]
+                        if idvalue=="-":
+                            continue
+                        if idtype=="uniprotkb":
+                        # In "uniprotkb" ids, I have found both UniprotEntries and UniprotAccession entries. 
+                        # For this reason, I have made one regex to identify the Entries
+                            if uniprot_entry_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotentry", value=idvalue, type="cross-reference") )
+                            else:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value=idvalue, type="cross-reference") )
+                        elif idtype=="refseq":
+                        # In "refseq" ids, I have found both RefSeq and GenBank Accession entries. 
+                        # For this reason, I have made two regex to identify them
+                            if refseq_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "refseq", value=idvalue, type="cross-reference") )
+                            elif gbaccession_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value=idvalue, type="cross-reference") )
+                        elif idtype=="entrezgene/locuslink":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "geneID", value=idvalue, type="cross-reference") )
+                        elif idtype=="cygd":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "cygd", value=idvalue, type="cross-reference") )
+                        elif idtype=="ipi":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "ipi", value=idvalue, type="cross-reference") )
+                        elif idtype=="flybase":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "flybase", value=idvalue, type="cross-reference") )
+                        elif idtype=="pdb":
+                        # There is the possibilty of having just the PDB of 4 letters, or the PDB plus the chain
+                        # For this reason, I have made a regex to identify the PDBs with chain and annotate them
+                            if pdb_chain_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference", additional_fields = {"chain": idvalue[-1]} ) )
+                            else:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference" ) )
+                        elif idtype=="gb":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="dbj":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="pir":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "pir", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="kegg":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "keggCode", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="emb":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="uniprot":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="swiss-prot":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="intact":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "intact", value = idvalue.replace("EBI-",""), type="cross-reference" ) )
+                        elif idtype=="genbank_protein_gi":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "GI", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="tigr":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "tigr", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="prf" or idtype=="pubmed" or idtype=="uniparc":
+                            pass
+                        else:
+                            pass
+                            #sys.stderr.write("Alternative id type %s not recognized\n" %idtype)
+
+                    aliases_ids = fields[fields_dict["aliasa"]].split("|")
+                    for current_id in aliases_ids:
+                        if current_id == "-":
+                            continue
+                        t = current_id.split(":")
+                        idtype = t[0].lower()
+                        idvalue = t[1]
+                        if idvalue=="-":
+                            continue
+                        if idtype=="uniprotkb":
+                        # In "uniprotkb" ids, I have found both UniprotEntries and UniprotAccession entries. 
+                        # For this reason, I have made one regex to identify the Entries
+                            if uniprot_entry_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotentry", value=idvalue, type="cross-reference") )
+                            else:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value=idvalue, type="cross-reference") )
+                        elif idtype=="refseq":
+                        # In "refseq" ids, I have found both RefSeq and GenBank Accession entries. 
+                        # For this reason, I have made two regex to identify them
+                            if refseq_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "refseq", value=idvalue, type="cross-reference") )
+                            elif gbaccession_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value=idvalue, type="cross-reference") )
+                        elif idtype=="entrezgene/locuslink":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "geneID", value=idvalue, type="cross-reference") )
+                        elif idtype=="cygd":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "cygd", value=idvalue, type="cross-reference") )
+                        elif idtype=="ipi":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "ipi", value=idvalue, type="cross-reference") )
+                        elif idtype=="flybase":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "flybase", value=idvalue, type="cross-reference") )
+                        elif idtype=="pdb":
+                        # There is the possibilty of having just the PDB of 4 letters, or the PDB plus the chain
+                        # For this reason, I have made a regex to identify the PDBs with chain and annotate them
+                            if pdb_chain_pattern.match(idvalue) != None:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference", additional_fields = {"chain": idvalue[-1]} ) )
+                            else:
+                                eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference" ) )
+                        elif idtype=="gb":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="dbj":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="pir":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "pir", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="kegg":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "keggCode", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="emb":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="uniprot":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="swiss-prot":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="intact":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "intact", value = idvalue.replace("EBI-",""), type="cross-reference" ) )
+                        elif idtype=="genbank_protein_gi":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "GI", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="tigr":
+                            eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "tigr", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="prf" or idtype=="pubmed" or idtype=="uniparc":
+                            pass
+                        else:
+                            #sys.stderr.write("Alternative id type %s not recognized\n" %idtype)
+                            pass
+
+
+                    # Example --> taxid:83333(Escherichia coli K-12)
+                    taxID = fields[fields_dict["taxa"]].replace("taxid:","").split("(")[0]
+                    if taxID!="-":
+                        eE1.add_attribute( ExternalEntityAttribute( attribute_identifier= "taxID", value=taxID, type = "cross-reference") )
+
+                    external_entities_dict[fields[0]] = self.biana_access.insert_new_external_entity( externalEntity = eE1 )
+
+                eE1_id = external_entities_dict[fields[0]]
+                
+
+            if "0326" in fields[fields_dict["interactor_type_b"]]:
+
+                if fields[1] not in external_entities_dict:
+
+                    eE2 = ExternalEntity( source_database = self.database, type="protein" )
+
+                    # Primary ids
+                    primary_id_t = fields[fields_dict["checksum_b"]]
+                    # Example --> rogid:6Y8uQAzJShSjVNH41+7FK8K1DXo9606
+                    t = primary_id_t.split(":")
+                    eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "irefindex_ROGID", value=t[1], type="cross-reference") )
+
+                    alternative_ids = fields[fields_dict["altb"]].split("|")
+                    for current_id in alternative_ids:
+                        if current_id == "-":
+                            continue
+                        t = current_id.split(":")
+                        idtype = t[0].lower()
+                        idvalue = t[1]
+                        if idvalue=="-":
+                            continue
+                        if idtype=="uniprotkb":
+                        # In "uniprotkb" ids, I have found both UniprotEntries and UniprotAccession entries. 
+                        # For this reason, I have made one regex to identify the Entries
+                            if uniprot_entry_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotentry", value=idvalue, type="cross-reference") )
+                            else:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value=idvalue, type="cross-reference") )
+                        elif idtype=="refseq":
+                        # In "refseq" ids, I have found both RefSeq and GenBank Accession entries. 
+                        # For this reason, I have made two regex to identify them
+                            if refseq_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "refseq", value=idvalue, type="cross-reference") )
+                            elif gbaccession_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value=idvalue, type="cross-reference") )
+                        elif idtype=="entrezgene/locuslink":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "geneID", value=idvalue, type="cross-reference") )
+                        elif idtype=="cygd":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "cygd", value=idvalue, type="cross-reference") )
+                        elif idtype=="ipi":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "ipi", value=idvalue, type="cross-reference") )
+                        elif idtype=="flybase":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "flybase", value=idvalue, type="cross-reference") )
+                        elif idtype=="pdb":
+                        # There is the possibilty of having just the PDB of 4 letters, or the PDB plus the chain
+                        # For this reason, I have made a regex to identify the PDBs with chain and annotate them
+                            if pdb_chain_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference", additional_fields = {"chain": idvalue[-1]} ) )
+                            else:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference" ) )
+                        elif idtype=="gb":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="dbj":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="pir":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "pir", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="kegg":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "keggCode", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="emb":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="uniprot":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="swiss-prot":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="intact":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "intact", value = idvalue.replace("EBI-",""), type="cross-reference" ) ) 
+                        elif idtype=="genbank_protein_gi":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "GI", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="tigr":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "tigr", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="prf" or idtype=="pubmed" or idtype=="uniparc":
+                            pass
+                        else:
+                            #sys.stderr.write("Alias id type %s not recognized\n" %idtype)
+                            pass
+
+                    aliases_ids = fields[fields_dict["aliasb"]].split("|")
+                    for current_id in aliases_ids:
+                        if current_id == "-":
+                            continue
+                        t = current_id.split(":")
+                        idtype = t[0].lower()
+                        idvalue = t[1]
+                        if idvalue=="-":
+                            continue
+                        if idtype=="uniprotkb":
+                        # In "uniprotkb" ids, I have found both UniprotEntries and UniprotAccession entries. 
+                        # For this reason, I have made one regex to identify the Entries
+                            if uniprot_entry_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotentry", value=idvalue, type="cross-reference") )
+                            else:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value=idvalue, type="cross-reference") )
+                        elif idtype=="refseq":
+                        # In "refseq" ids, I have found both RefSeq and GenBank Accession entries. 
+                        # For this reason, I have made two regex to identify them
+                            if refseq_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "refseq", value=idvalue, type="cross-reference") )
+                            elif gbaccession_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value=idvalue, type="cross-reference") )
+                        elif idtype=="entrezgene/locuslink":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "geneID", value=idvalue, type="cross-reference") )
+                        elif idtype=="cygd":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "cygd", value=idvalue, type="cross-reference") )
+                        elif idtype=="ipi":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "ipi", value=idvalue, type="cross-reference") )
+                        elif idtype=="flybase":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "flybase", value=idvalue, type="cross-reference") )
+                        elif idtype=="pdb":
+                        # There is the possibilty of having just the PDB of 4 letters, or the PDB plus the chain
+                        # For this reason, I have made a regex to identify the PDBs with chain and annotate them
+                            if pdb_chain_pattern.match(idvalue) != None:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference", additional_fields = {"chain": idvalue[-1]} ) )
+                            else:
+                                eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "pdb", value=idvalue[0:4], type="cross-reference" ) )
+                        elif idtype=="gb":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="dbj":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="pir":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "pir", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="kegg":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "keggCode", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="emb":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "accessionnumber", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="uniprot":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="swiss-prot":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "uniprotaccession", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="intact":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "intact", value = idvalue.replace("EBI-",""), type="cross-reference" ) )
+                        elif idtype=="genbank_protein_gi":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "GI", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="tigr":
+                            eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "tigr", value = idvalue, type="cross-reference" ) )
+                        elif idtype=="prf" or idtype=="pubmed" or idtype=="uniparc":
+                            pass
+                        else:
+                            #sys.stderr.write("Alias id type %s not recognized\n" %idtype)
+                            pass
+
+                    taxID = fields[fields_dict["taxb"]].replace("taxid:","").split("(")[0]
+                    if taxID!="-":
+                        eE2.add_attribute( ExternalEntityAttribute( attribute_identifier= "taxID", value=taxID, type = "cross-reference") )
+
+                    external_entities_dict[fields[1]] = self.biana_access.insert_new_external_entity( externalEntity = eE2 )
+
+                eE2_id = external_entities_dict[fields[1]]
+
+
+            ######################################
+            ## INTERACTION SPECIFIC INFORMATION ##
+            ######################################
+
+            rigid_id = fields[fields_dict["checksum_interaction"]]
+            
+
+            add_common_attributes = True
+
+            # Does the edge represent a binary interaction (X), complex membership (C), or a multimer (Y)?
+            edgetype = fields[fields_dict["edgetype"]]
+            if edgetype=="X":
+                eEr = ExternalEntityRelation( source_database = self.database, relation_type = "interaction" )
+            # When edgetype is a complex, the row contains the interactor "A" which is the complex, and the interactor "B" which is one of the proteins of the complex
+            # We only annotate the protein of the complex, and we relate this protein with the other proteins of the complex by the "rigid" of the complex
+            elif edgetype=="C":
+                if rigid_id in external_entity_relations_dict:
+                    add_common_attributes = False
+                eEr = external_entity_relations_dict.setdefault(rigid_id, ExternalEntityRelation( source_database = self.database, relation_type = "complex" ) )
+            elif edgetype=="Y":
+                eEr = ExternalEntityRelation( source_database = self.database, relation_type = "interaction" )
+
+                
+            if "0326" in fields[fields_dict["interactor_type_a"]]:
+                eEr.add_participant( externalEntityID = eE1_id )
+            
+            if "0326" in fields[fields_dict["interactor_type_b"]]:
+                eEr.add_participant( externalEntityID = eE2_id )
+
+
+            if edgetype=="Y":
+                eEr.add_participant_attribute(externalEntityID = eE1_id,
+                                              participantAttribute = ExternalEntityRelationParticipantAttribute( attribute_identifier = "cardinality", 
+                                                                                                                 value = fields[fields_dict["numparticipants"]] ))
+            else:
+                if "0326" in fields[fields_dict["interactor_type_b"]]:
+                    eEr.add_participant( externalEntityID = eE2_id )
+                                              
+
+            
+            if add_common_attributes:
+
+                eEr.add_attribute( ExternalEntityAttribute( attribute_identifier = "iRefIndex_RIGID", value = rigid_id.replace("rigid:",""), type="unique" ) )
+
+                # pubmed:9199353|pubmed:10413469|pubmed:14759368|pubmed:11805826
+                pubmeds = fields[fields_dict["pmids"]].split("|")
+                for current_pubmed in pubmeds:
+                    pubmed_id = current_pubmed.replace("pubmed:","").strip()
+                    if pubmed_id != "-" and not pubmed_id.startswith("unassigned") and pubmed_id!="-2" and pubmed_id!="null":
+                        eEr.add_attribute( ExternalEntityAttribute( attribute_identifier= "pubmed", value=current_pubmed.replace("pubmed:",""), type="cross-reference") )
+
+
+                # METHOD
+                methods = fields[fields_dict["method"]].split("|")
+                # Example of one method --> MI:0090(protein complementation assay)
+                # Example of multiple methods --> MI:0090(protein complementation assay)|MI:0228(cytoplasmic complementation assay)|MI:0230(membrane bound complementation assay)
+                for current_method in methods:
+                    m = mi_re.match(current_method)
+                    if m:
+                        try:
+	                        # I will take directly the MI of the method from the regex
+	                        method_MI = m.group(1)
+	                        method_name = m.group(2).lower()
+	                        if method_name=="-" or method_name=="other" or method_name=="not-specified" or method_name=="na":
+	                            continue
+	                        #method_MI = obo_name_to_MI[method_name] # This was from the old version of the parser, but I think that it is not necessary
+	                        if method_MI is not None:
+	                            eEr.add_attribute( ExternalEntityAttribute( attribute_identifier= "method_id", value=method_MI, type="cross-reference" ) )
+                        except:
+                            sys.stderr.write("Method MI not found: %s\n" %m.group(2))
+
+                
+                # CONFIDENCE
+                confidences = fields[fields_dict["confidence"]].split("|")
+                # Example --> ['hpr:37298', 'lpr:37298', 'np:1']
+ 
+                for current_confidence in confidences:
+                    if current_confidence.startswith("lpr"):
+                        eEr.add_attribute( ExternalEntityAttribute( attribute_identifier= "iRefIndex_lpr", value=current_confidence[4:] ) )
+                    elif current_confidence.startswith("hpr"):
+                        eEr.add_attribute( ExternalEntityAttribute( attribute_identifier= "iRefIndex_hpr", value=current_confidence[4:] ) )
+                    elif current_confidence.startswith("np"):
+                        eEr.add_attribute( ExternalEntityAttribute( attribute_identifier= "iRefIndex_np", value=current_confidence[3:] ) )
+
+            if edgetype != "C":
+                self.biana_access.insert_new_external_entity( externalEntity = eEr )
+
+
+        # Insert all complexes
+        for current_complex_eEr in external_entity_relations_dict.values():
+            self.biana_access.insert_new_external_entity( externalEntity = current_complex_eEr )
+
+
+
+            
+
+
+                    
+
+                    
+            
+            
+

--- a/biana/BianaParser/ipiParser.py
+++ b/biana/BianaParser/ipiParser.py
@@ -172,11 +172,14 @@ class IPIParser(BianaParser):
                                                                      value = search.group(1),
 								     type = "cross-reference"))
 
+                # Quim Aguirre: Change to add the gene symbol using the regex, add multiple entries when necessary, and skip when '-'
                 search = gene_symbol_regex.search(line)
-                if search:
-                    ipi_object.add_attribute(ExternalEntityAttribute(attribute_identifier="geneSymbol",
-                                                                     value = actual_value,
-                                                                     type = "cross-reference" ))
+                gene_symbols = search.group(1).split(';')
+                for gene_symbol in gene_symbols:
+                    if search and gene_symbol != '-':
+                        ipi_object.add_attribute(ExternalEntityAttribute(attribute_identifier="geneSymbol",
+                                                                         value = gene_symbol,
+                                                                         type = "cross-reference" ))
 
                     search2 = re.search("[Emb|Gb]\|(\S+)",search.group(2))
                     if search2:

--- a/biana/BianaParser/psi_Mi25Parser.py
+++ b/biana/BianaParser/psi_Mi25Parser.py
@@ -455,9 +455,14 @@ class Psi_MiFormattedDBParser(BianaParser):
     def decideAliasTypeSpecificConversions(self, type):
         #nameType = ""
         attributeName = "ignore"
-        if type == "gene name" or type == "gene name synonym":
-            attributeName = "GeneSymbol"
+        if type == "gene name":
+            # Example of gene name: EEF1A2
+            attributeName = "GeneSymbol" # Quim Aguirre: If it is gene name, we will introduce it in the GeneSymbol table
             #nameType = "alias"
+        elif type == "gene name synonym":
+            # Example of gene name synonym: Eukaryotic elongation factor 1 A-2
+            attributeName = "ignore" # Quim Aguirre: If it is gene name synonym, we will ignore because we have enough information in the database
+            #nameType = "cross-reference"
         elif type == "orf name":
             attributeName = "orfName"
             #nameType = "cross-reference"

--- a/biana/BianaParser/scopParser.py
+++ b/biana/BianaParser/scopParser.py
@@ -18,7 +18,6 @@
 """
 
 from bianaParser import *
-from sets import *
 import os
 from biana.BianaObjects.PDB import PDBFragment
 
@@ -96,7 +95,8 @@ class SCOPParser(BianaParser):
         if not self.input_file.endswith(os.sep):
             self.input_file += os.sep
 
-        scop_dir_cla_fd = file(self.input_file+"dir.cla.scop.txt_"+self.sourcedb_version.replace("\"",""),'r')
+        # dir.cla.scop(e).txt - Full classification for each domain
+        scop_dir_cla_fd = file(self.input_file+"dir.cla.scope."+self.sourcedb_version.replace("\"","")+"-stable.txt",'r')
 
         for line in scop_dir_cla_fd:
 
@@ -104,11 +104,13 @@ class SCOPParser(BianaParser):
 		continue
             
 	    line_fields = line.strip().split()   # line_fields[0] is complete pdb entry
-                                       		 # line_fields[1] is pdb code
+                                       		 # line_fields[1] is PDB ID code
 	                                         # line_fields[2] is pdb chain follow by : XX-YY (optional)
-        	                                 # line_fields[3] is ???
-                	                         # line_fields[4] is ???
-                        	                 # line_fields[5] is comma-separated codes
+        	                                 # line_fields[3] is sccs???
+                	                         # line_fields[4] is sunid???
+                        	                 # line_fields[5] is comma-separated codes: sunids of ancestor nodes in comma-delimited list
+
+        # Example --> d1ux8a_	1ux8	A:	a.1.1.1	113449	cl=46456,cf=46457,sf=46458,fa=46459,dm=46460,sp=116748,px=113449
 
             if len(line_fields) != 6:
                 # skip incomplete lines
@@ -137,7 +139,7 @@ class SCOPParser(BianaParser):
             hierarchy_dict["dm"][dm] = fa
 
             #sp_dict.setdefault(dm,new_list()).append(sp)
-            sp_dict.setdefault(dm,Set(new_list())).add(sp)
+            sp_dict.setdefault(dm,set(new_list())).add(sp)
             domains_dict.setdefault(dm,new_list()).append((pdb_code,range))
             #domains_to_id_dict[dm] = line_fields[3]
 
@@ -147,7 +149,8 @@ class SCOPParser(BianaParser):
         #print len(sp_dict), sp_dict
         #print len(domains_dict), domains_dict
 
-        scop_des_fd = file(self.input_file+"dir.des.scop.txt_"+self.sourcedb_version.replace("\"",""),'r')
+        # dir.des.scop(e).txt. - Descriptions for each node in the SCOP(e) hierarchy.
+        scop_des_fd = file(self.input_file+"dir.des.scope."+self.sourcedb_version.replace("\"","")+"-stable.txt",'r')
 
         for line in scop_des_fd:
 
@@ -155,7 +158,16 @@ class SCOPParser(BianaParser):
                 continue
 
 	    line_fields = line.strip().split("\t")
-            descriptions_dict[line_fields[1]][line_fields[0]] = line_fields[4]
+            # descriptions_dict["category"]["sunid"] = description
+            descriptions_dict[line_fields[1]][line_fields[0]] = line_fields[4] 
+
+                # line_fields[0] is sunid
+                # line_fields[1] is level: cl - class; cf - fold; sf - superfamily; fa - family; dm - protein; sp - species; px - domain
+	            # line_fields[2] is sccs
+        	    # line_fields[3] is sid or "-"
+                # line_fields[4] is description
+
+        # Example --> 46456	cl	a	-	All alpha proteins
 
         scop_des_fd.close()
 

--- a/biana/biana_globals.py
+++ b/biana/biana_globals.py
@@ -139,7 +139,7 @@ EXTERNAL_ENTITY_GENERAL_ATTRIBUTES = []
 PROMISCUOUS_EXTERNAL_ENTITY_TYPES_DICT = [ ("SCOPElement", "PDB") ]
 
 
-VALID_IDENTIFIER_REFERENCE_TYPES = ["unique", "previous", "alias", "cross-reference", "synonym","short-name", "exact_synonym", "related_synonym"]
+VALID_IDENTIFIER_REFERENCE_TYPES = ["unique", "previous", "alias", "cross-reference", "synonym","short-name", "exact_synonym", "related_synonym", "broad_synonym", "narrow_synonym"]
 
 CROSSABLE_ATTRIBUTES = set(["sequence","taxid","ipi","uniprotentry","uniprotaccession","genesymbol","geneid","refseq","ec"])
 


### PR DESCRIPTION
  - gooboParser.py: addition of broad/narrow synonyms, alternative ids, skip of typedef terms
  - biana_globals.py: addition of broad/narrow synonyms
  - cogParser_2014.py: adapted parser for the 2014 release of COG
  - hgncParser_2016.py: adapted parser for the HGNC release of 2016 
  - iRefIndexParser_2016.py: adapted parser for the iRefIndex release of 2016
  - scopParser.py: change in the handling of the database files
  - psi_Mi25Parser.py: change to classify "gene name" alias entries in the GeneSymbol table
  - ipiParser.py: change to add correctly gene symbols, add them multiple times and skip empty entries